### PR TITLE
= Remove dependency to Spray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,5 +23,5 @@ lazy val root = (project in file("."))
   .settings(formatSettings: _*)
   .settings(
       libraryDependencies ++=
-        compileScope(kamonCore, sprayCan, sprayClient, sprayRouting, akkaSlf4j) ++
-        testScope(scalatest, sprayCan, sprayClient, akkaTestKit, slf4jApi, slf4jnop))
+        compileScope(kamonCore, akkaSlf4j, asyncHttpClient) ++
+        testScope(scalatest, akkaTestKit, slf4jApi, slf4jnop))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,6 @@ object Dependencies {
 
   val kamonVersion      = "0.6.3"
   val akkaVersion       = "2.3.14"
-  val sprayVersion      = "1.3.3"
   val slf4jVersion      = "1.7.7"
 
   val kamonCore         = "io.kamon"                  %%  "kamon-core"            % kamonVersion
@@ -33,9 +32,7 @@ object Dependencies {
   val akkaSlf4j         = "com.typesafe.akka"         %%  "akka-slf4j"            % akkaVersion
   val akkaTestKit       = "com.typesafe.akka"         %%  "akka-testkit"          % akkaVersion
 
-  val sprayCan          = "io.spray"                  %%  "spray-can"             % sprayVersion
-  val sprayRouting      = "io.spray"                  %%  "spray-routing"         % sprayVersion
-  val sprayClient       = "io.spray"                  %%  "spray-client"          % sprayVersion
+  val asyncHttpClient   = "org.asynchttpclient"       %   "async-http-client"     % "2.0.24"
 
   val slf4jApi          = "org.slf4j"                 %   "slf4j-api"             % slf4jVersion
   val slf4jnop          = "org.slf4j"                 %   "slf4j-nop"             % slf4jVersion


### PR DESCRIPTION
Spray will not be compatible with Scala 2.13, therefore we should
replace the HTTP client used to send data to InfluxDB with
AsyncHTTPClient.