### PR TITLE
+ add configurable sending # of measurements

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,6 +24,9 @@ kamon {
     # For histograms, which percentiles to count
     percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
 
+    # Include number of measurements?
+    include-measurements = no
+
     # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
     # collection for your desired entities must be activated under the kamon.metrics.filters settings.
     subscriptions {

--- a/src/main/scala/kamon/influxdb/TagsGenerator.scala
+++ b/src/main/scala/kamon/influxdb/TagsGenerator.scala
@@ -39,6 +39,7 @@ trait TagsGenerator {
   }
 
   protected val percentiles = config.getDoubleList("percentiles").toList
+  protected val includeMeasurements = config.getBoolean("include-measurements")
 
   protected def generateTags(entity: Entity, metricKey: MetricKey): Map[String, String] =
     entity.category match {
@@ -57,10 +58,13 @@ trait TagsGenerator {
     }
 
   protected def histogramValues(hs: Histogram.Snapshot): Map[String, BigDecimal] = {
+    val measurements =
+      if (includeMeasurements) Map("measurements" -> BigDecimal(hs.numberOfMeasurements))
+      else Map.empty
     val defaults = Map(
       "lower" -> BigDecimal(hs.min),
       "mean" -> average(hs),
-      "upper" -> BigDecimal(hs.max))
+      "upper" -> BigDecimal(hs.max)) ++ measurements
 
     percentiles.foldLeft(defaults) { (acc, p) ⇒
       val fractional = p % 1

--- a/src/test/resources/http_test.conf
+++ b/src/test/resources/http_test.conf
@@ -28,6 +28,7 @@ kamon {
     hostname-override = "overridden"
 
     percentiles = [50.0, 70.5]
+    include-measurements = no
   }
 
   influx-with-auth-and-rp {
@@ -41,6 +42,7 @@ kamon {
     hostname-override = none
 
     percentiles = [50.0, 70.5]
+    include-measurements = no
 
     authentication {
       user = "test-user"
@@ -48,5 +50,19 @@ kamon {
     }
 
     retention-policy = "six_month_rollup"
+  }
+
+  influxdb-with-measurements {
+    hostname = "127.0.0.1"
+    port = 0
+    max-packet-size = 1024
+    database = "mydb"
+    protocol = "http"
+
+    application-name = "kamon"
+    hostname-override = none
+
+    percentiles = [50.0, 70.5]
+    include-measurements = yes
   }
 }

--- a/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
+++ b/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
@@ -77,6 +77,7 @@ class HttpBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxd
     val influxDBConfig = config.getConfig("kamon.influxdb")
     val configWithAuthAndRetention = config.getConfig("kamon.influx-with-auth-and-rp")
     val configWithHostnameOverride = config.getConfig("kamon.influxdb-hostname-override")
+    val configWithMeasurementsEnabled = config.getConfig("kamon.influxdb-with-measurements")
 
     "use the overriden hostname, if provided" in new HttpSenderFixture(configWithHostnameOverride) {
       val testrecorder = buildRecorder("user/kamon")
@@ -140,6 +141,22 @@ class HttpBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxd
 
       requestData should contain(expectedMessage)
     }
+
+    "send number of measurements, if enabled" in new HttpSenderFixture(configWithMeasurementsEnabled) {
+      val testRecorder = buildRecorder("user/kamon")
+
+      testRecorder.histogramOne.record(10L)
+      testRecorder.histogramOne.record(5L)
+
+      val http = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-timers,category=test,entity=user-kamon,hostname=$hostName,metric=metric-one measurements=2,mean=7.5,lower=5,upper=10,p70.5=10,p50=5 ${from.millis * 1000000}"
+
+      val request = getHttpRequest(http)
+      val requestData = request.payload.split("\n")
+
+      requestData should contain(expectedMessage)
+    }
+
   }
 }
 


### PR DESCRIPTION
Provides ability to automatically include number of measurements into histogram values. This allows `kamon-influxdb` to (almost) automatically provide trace counts, and also saves from separate tracking of counts in quite many scenarios.