### PR TITLE
+ add optional extra tags

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,6 +24,9 @@ kamon {
     # For histograms, which percentiles to count
     percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
 
+    # extra tags
+    extra-tags = {}
+
     # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
     # collection for your desired entities must be activated under the kamon.metrics.filters settings.
     subscriptions {

--- a/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
+++ b/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
@@ -34,7 +34,7 @@ case class BatchInfluxDBMetricsPacker(config: Config) extends InfluxDBMetricsPac
       (entity, snapshot) ← tick.metrics
       (metricKey, metricSnapshot) ← snapshot.metrics
     } {
-      val tags = generateTags(entity, metricKey) ++ entity.tags
+      val tags = generateTags(entity, metricKey)
 
       metricSnapshot match {
         case hs: Histogram.Snapshot ⇒

--- a/src/main/scala/kamon/influxdb/MetricDataPacketBuilder.scala
+++ b/src/main/scala/kamon/influxdb/MetricDataPacketBuilder.scala
@@ -20,10 +20,10 @@ class MetricDataPacketBuilder(maxPacketSizeInBytes: Long, flushToDestination: St
   protected val metricSeparator = "\n"
   protected var buffer = new StringBuilder()
 
-  protected def createInfluxString(data: Map[String, Any]): String =
+  protected def createInfluxString(data: TraversableOnce[(String, Any)]): String =
     data.map { case (k, v) ⇒ s"$k=$v" }.mkString(",")
 
-  def appendMeasurement(key: String, tags: Map[String, String], measurementData: Map[String, BigDecimal], timeStamp: Long): Unit = {
+  def appendMeasurement(key: String, tags: TraversableOnce[(String, String)], measurementData: TraversableOnce[(String, BigDecimal)], timeStamp: Long): Unit = {
     val tagsString = createInfluxString(tags)
     val valuesString = createInfluxString(measurementData)
     val data = s"$key,$tagsString $valuesString $timeStamp$metricSeparator"

--- a/src/main/scala/kamon/influxdb/TagsGenerator.scala
+++ b/src/main/scala/kamon/influxdb/TagsGenerator.scala
@@ -49,22 +49,14 @@ trait TagsGenerator {
   }
 
   protected def generateTags(entity: Entity, metricKey: MetricKey): Map[String, String] = {
-    val baseTags = entity.category match {
-      case "trace-segment" ⇒
-        Seq(
-          "category" -> normalize(entity.tags("trace")),
-          "entity" -> normalize(entity.name),
-          "hostname" -> normalize(hostname),
-          "metric" -> normalize(metricKey.name))
-      case _ ⇒
-        Seq(
-          "category" -> normalize(entity.category),
-          "entity" -> normalize(entity.name),
-          "hostname" -> normalize(hostname),
-          "metric" -> normalize(metricKey.name))
-    }
-    if (extraTags.isEmpty && entity.tags.isEmpty) Map(baseTags: _*) // up to 4 elements Map preserves order?
-    else ListMap((baseTags ++ extraTags ++ entity.tags).sortBy(_._1): _*)
+    val baseTags = Seq(
+      "category" -> normalize(entity.category),
+      "entity" -> normalize(entity.name),
+      "hostname" -> normalize(hostname),
+      "metric" -> normalize(metricKey.name))
+    val entityTags = if (entity.category == "trace-segment") entity.tags - "category" else entity.tags
+    if (extraTags.isEmpty && entityTags.isEmpty) Map(baseTags: _*) // up to 4 elements Map preserves order?
+    else ListMap((baseTags ++ extraTags ++ entityTags).sortBy(_._1): _*) // from InfluxDB's "Line Protocol Tutorial": For best performance you should sort tags by key before sending them to the database.
   }
 
   protected def histogramValues(hs: Histogram.Snapshot): Map[String, BigDecimal] = {

--- a/src/test/resources/http_test.conf
+++ b/src/test/resources/http_test.conf
@@ -28,6 +28,7 @@ kamon {
     hostname-override = "overridden"
 
     percentiles = [50.0, 70.5]
+    extra-tags = {}
   }
 
   influx-with-auth-and-rp {
@@ -41,6 +42,7 @@ kamon {
     hostname-override = none
 
     percentiles = [50.0, 70.5]
+    extra-tags = {}
 
     authentication {
       user = "test-user"
@@ -48,5 +50,13 @@ kamon {
     }
 
     retention-policy = "six_month_rollup"
+  }
+
+  influxdb-with-extra-tags = ${kamon.influxdb}
+  influxdb-with-extra-tags.extra-tags = {
+    tag1 = "string"
+    tag2 = 100
+    tag3 = 99.5
+    tag4 = false
   }
 }

--- a/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
+++ b/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
@@ -77,6 +77,7 @@ class HttpBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxd
     val influxDBConfig = config.getConfig("kamon.influxdb")
     val configWithAuthAndRetention = config.getConfig("kamon.influx-with-auth-and-rp")
     val configWithHostnameOverride = config.getConfig("kamon.influxdb-hostname-override")
+    val configWithExtraTags= config.getConfig("kamon.influxdb-with-extra-tags")
 
     "use the overriden hostname, if provided" in new HttpSenderFixture(configWithHostnameOverride) {
       val testrecorder = buildRecorder("user/kamon")
@@ -134,6 +135,18 @@ class HttpBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxd
 
       val http = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
       val expectedMessage = s"kamon-timers,category=test,entity=user-kamon,hostname=$hostName,metric=metric-one mean=7.5,lower=5,upper=10,p70.5=10,p50=5 ${from.millis * 1000000}"
+
+      val request = getHttpRequest(http)
+      val requestData = request.payload.split("\n")
+
+      requestData should contain(expectedMessage)
+    }
+    "send extra tags, if configured" in new HttpSenderFixture(configWithExtraTags) {
+      val testRecorder = buildRecorder("user/kamon")
+      testRecorder.counter.increment()
+
+      val http = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-counters,category=test,entity=user-kamon,hostname=$hostName,metric=metric-two,tag1=string,tag2=100,tag3=99-5,tag4=false value=1 ${from.millis * 1000000}"
 
       val request = getHttpRequest(http)
       val requestData = request.payload.split("\n")


### PR DESCRIPTION
I beg your pardon for including two commits in this PR, but there is a reason to it, as the second commit introduces what one can consider breaking changes and yet it depends on first commit.

"configurable extra-tags" commit provides an ability to specify extra tags to send along with all entity measurements. This is useful in a situation when one has multiple "similar" applications, and needs both the ability to seem them as one and to partition them based on criteria. One example (our case) is staged roll-out, when multiple versions of the application run alongside for days and even weeks.

"usable tags for trace-segments" changes the way InfluxDB's tags are built for "trace segments". The old way was:
- first, `category` was set to name of the original trace (which would pollute `category` namespace enormously, if not for the text bullet)
- then original entity tags were appended, and those overwrote `category` tag with a "segment category", which usually was some meaningless "instrumented" string

The new way (for trace segment only):
- `category` tag is always "trace-segment"
- original trace name is available under `trace` tag
- actual "segment category" is not included in tags at all