### PR TITLE
2 performance tweaks

### DIFF
--- a/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
+++ b/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
@@ -34,13 +34,14 @@ case class BatchInfluxDBMetricsPacker(config: Config) extends InfluxDBMetricsPac
       (entity, snapshot) ← tick.metrics
       (metricKey, metricSnapshot) ← snapshot.metrics
     } {
-      val tags = generateTags(entity, metricKey)
+      def tags = generateTags(entity, metricKey)
 
       metricSnapshot match {
         case hs: Histogram.Snapshot ⇒
           if (!hs.isEmpty) packetBuilder.appendMeasurement(s"$application-timers", tags, histogramValues(hs), timestamp * 1000000)
         case cs: Counter.Snapshot ⇒
-          packetBuilder.appendMeasurement(s"$application-counters", tags, Map("value" -> BigDecimal(cs.count)), timestamp * 1000000)
+          if (cs.count != 0)
+            packetBuilder.appendMeasurement(s"$application-counters", tags, Map("value" -> BigDecimal(cs.count)), timestamp * 1000000)
       }
     }
 


### PR DESCRIPTION
- `tags` are not always used; compute them on demand.
- don't send 0 counts. In the case of counters,
  the absence of an event results to a value of zero.

These changes have been running on https://lichess.org
for several months now (using a Kamon fork)