### PR TITLE
Escape query arguments in a destination's URL

### DIFF
--- a/src/main/scala/kamon/influxdb/InfluxDBClient.scala
+++ b/src/main/scala/kamon/influxdb/InfluxDBClient.scala
@@ -16,7 +16,7 @@
 
 package kamon.influxdb
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, URLEncoder}
 
 import akka.actor._
 import akka.event.{ Logging, LoggingAdapter }
@@ -74,7 +74,7 @@ class InfluxDBHttpClient(config: Config, httpClient: HttpClient) extends InfluxD
       withAuth
     }
 
-    val queryString = query.map { case (key, value) ⇒ s"$key=$value" } match {
+    val queryString = query.map { case (key, value) ⇒ s"$key=${URLEncoder.encode(value, "UTF-8")}" } match {
       case Nil ⇒ ""
       case xs  ⇒ s"?${xs.mkString("&")}"
     }


### PR DESCRIPTION
This could break a sending of data to the InfluxDB if you relied on this bug and escaped a username/password/etc by yourself.