### PR TITLE
Kamon - InfluxDB: Add common tags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@
  * =========================================================================================
  */
 
-val kamonCore        = "io.kamon"             %% "kamon-core"    % "1.0.0"
-val kamonTestkit     = "io.kamon"             %% "kamon-testkit" % "1.0.0"
+val kamonCore        = "io.kamon"             %% "kamon-core"    % "1.1.0"
+val kamonTestkit     = "io.kamon"             %% "kamon-testkit" % "1.1.0"
 val okHttp           = "com.squareup.okhttp3" %  "okhttp"        % "3.9.1"
 val okHttpMockServer = "com.squareup.okhttp3" %  "mockwebserver" % "3.9.1"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,6 +10,9 @@ kamon.influxdb {
 
     # For histograms, which percentiles to count
     percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
+
+    # Disable sending of env tags by default
+    env-tags-enabled = false
   
   modules {
     kamon-influxdb {

--- a/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
+++ b/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
@@ -13,8 +13,7 @@ class InfluxDBReporter extends MetricReporter {
   private val logger = LoggerFactory.getLogger(classOf[InfluxDBReporter])
   private var settings = InfluxDBReporter.readSettings(Kamon.config())
   private val client = buildClient(settings)
-
-  private def env = Kamon.environment
+  private var env = Kamon.environment
 
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
     val request = new Request.Builder()
@@ -43,6 +42,7 @@ class InfluxDBReporter extends MetricReporter {
   override def stop(): Unit = {}
 
   override def reconfigure(config: Config): Unit = {
+    env = Kamon.environment
     settings = InfluxDBReporter.readSettings(config)
   }
 

--- a/src/test/scala/kamon/influxdb/InfluxDBCustomMatchers.scala
+++ b/src/test/scala/kamon/influxdb/InfluxDBCustomMatchers.scala
@@ -50,6 +50,7 @@ trait InfluxDBCustomMatchers {
   def getLineProtocol(point: String): LineProtocol = {
     val parts = point.split(" ")
 
+    assert(parts.length == 3, "Line protocol incorrectly formatted")
     val measurementAndTags = parts(0).split(",").toList
 
     val (measurement, tags): (String, List[String]) = measurementAndTags match {

--- a/src/test/scala/kamon/influxdb/InfluxDBCustomMatchers.scala
+++ b/src/test/scala/kamon/influxdb/InfluxDBCustomMatchers.scala
@@ -1,0 +1,68 @@
+package kamon.influxdb
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+trait InfluxDBCustomMatchers {
+
+  case class LineProtocol(measurement: String, tags: Seq[String], fields: Seq[String], timestamp: Option[String])
+  class LineProtocolMatcher(expectedPoint: String) extends Matcher[String] {
+
+
+    def apply(left: String) = {
+
+      val leftLP = getLineProtocol(left)
+      val expectedLP = getLineProtocol(expectedPoint)
+
+      val failureMessage = new StringBuilder
+
+      def measurementMatches = {
+        val res = leftLP.measurement == expectedLP.measurement
+        if (!res) failureMessage ++= "Measurement did not match. "
+        res
+      }
+
+      def tagsMatch = {
+        val res = leftLP.tags.sorted == expectedLP.tags.sorted
+        if (!res) failureMessage ++= "Tags did not match "
+        res
+      }
+
+      def fieldsMatch = {
+        val res = leftLP.fields.sorted == expectedLP.fields.sorted
+        if (!res) failureMessage ++= "Fields did not match. "
+        res
+      }
+
+      def timestampsMatch = {
+        val res = leftLP.timestamp == expectedLP.timestamp
+        if (!res) failureMessage ++= "Timestamp did not match. "
+        res
+      }
+
+      MatchResult(
+        measurementMatches && tagsMatch && fieldsMatch && timestampsMatch,
+        s"${expectedLP.measurement}: ${failureMessage.toString} $left did not match expected result: $expectedPoint.",
+        "Line Protocol Point matched expectations"
+      )
+    }
+  }
+
+  def getLineProtocol(point: String): LineProtocol = {
+    val parts = point.split(" ")
+
+    val measurementAndTags = parts(0).split(",").toList
+
+    val (measurement, tags): (String, List[String]) = measurementAndTags match {
+      case x::xs => (x, xs)
+    }
+
+    val metric = parts(1).split(",")
+    val timestamp = if(parts(2).nonEmpty) Some(parts(2)) else None
+    LineProtocol(measurement, tags, metric, timestamp)
+  }
+
+  def matchExpectedLineProtocolPoint(expectedPoint: String) = new LineProtocolMatcher(expectedPoint)
+
+}
+
+object InfluxDBCustomMatchers extends InfluxDBCustomMatchers

--- a/src/test/scala/kamon/influxdb/InfluxDBReporterSpec.scala
+++ b/src/test/scala/kamon/influxdb/InfluxDBReporterSpec.scala
@@ -74,6 +74,7 @@ class InfluxDBReporterSpec extends WordSpec with Matchers with BeforeAndAfterAll
         |kamon.influxdb {
         |  hostname = ${influxDB.getHostName}
         |  port = ${influxDB.getPort}
+        |  env-tags-enabled = true
         |}
       """.stripMargin
     ).withFallback(Kamon.config()))


### PR DESCRIPTION
	- update Kamon dependency to 1.1.0
	- send common/env tags (host/service/instance) and any defined
	in config at kamon.environment.env
	- added custom matcher to provide more granularity on test failures
	and ignore order on lists of tags/fields