### PR TITLE
Configurable protocol, 

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,9 @@ kamon.influxdb {
   # For histograms, which percentiles to count
   percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
 
+  # The protocol to use when used to connect to your InfluxDB: HTTP/HTTPS
+  protocol = "http"
+
   # Allow including environment information as tags on all reported metrics.
   additional-tags {
 

--- a/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
+++ b/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
@@ -150,10 +150,10 @@ object InfluxDBReporter {
     val host = root.getString("hostname")
     val port = root.getInt("port")
     val database = root.getString("database")
-    val url = s"http://${host}:${port}/write?precision=s&db=${database}"
+    val protocol = root.getString("protocol").toLowerCase
+    val url = s"$protocol://$host:$port/write?precision=s&db=$database"
 
     val additionalTags = EnvironmentTagBuilder.create(root.getConfig("additional-tags"))
-
     Settings(
       url,
       root.getDoubleList("percentiles").asScala.map(_.toDouble),


### PR DESCRIPTION
At the moment URL is hard-coded to use `http`, making the reporter unusable to connect to remote instances that use https.