### PR TITLE
Properly escape measurement names

### DIFF
--- a/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
+++ b/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
@@ -81,7 +81,7 @@ class InfluxDBReporter(config: Config = Kamon.config()) extends MetricReporter {
 
   private def writeNameAndTags(builder: StringBuilder, name: String, metricTags: Map[String, String]): Unit = {
     builder
-      .append(name)
+      .append(escapeName(name))
 
     val tags = if(settings.additionalTags.nonEmpty) metricTags ++ settings.additionalTags else metricTags
 
@@ -98,6 +98,11 @@ class InfluxDBReporter(config: Config = Kamon.config()) extends MetricReporter {
 
     builder.append(' ')
   }
+
+  private def escapeName(in: String): String =
+    in.replace(" ", "\\ ")
+      .replace(",", "\\,")
+
 
   private def escapeString(in: String): String =
     in.replace(" ", "\\ ")


### PR DESCRIPTION
When sending a measurement that has a space or a ',' in the name InfluxDB cannot parse the line. This adds escaping for the name field as described in InfluxDB line protocol: https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#special-characters-and-keywords