### PR TITLE
write a "mean" field, equal to sum/count

### DIFF
--- a/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
+++ b/src/main/scala/kamon/influxdb/InfluxDBReporter.scala
@@ -109,6 +109,7 @@ class InfluxDBReporter extends MetricReporter {
         writeNameAndTags(builder, metric.name, instrument.tags)
         writeIntField(builder, "count", instrument.value.count)
         writeIntField(builder, "sum", instrument.value.sum)
+        writeIntField(builder, "mean", instrument.value.sum / instrument.value.count)
         writeIntField(builder, "min", instrument.value.min)
 
         percentiles.foreach { p =>


### PR DESCRIPTION
I feel it is necessary to denormalize this field.
Whereas using `sum(sum)/sum(count)` is possible, it is very inconvenient.
In grafana, it doesn't play well with field selectors.

Maybe add a kamon-influxdb setting to enable/disable writing "mean"?